### PR TITLE
[Feat] #12 히스토리 페이지 UI 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from './App';
 import Example from './components/Example';
-import Homepage from './pages/Homepage';
+import Homepage from './pages/HomePage';
 import OnboardingPage from './pages/OnboardingPage';
 import LoginPage from './pages/LoginPage';
 import SelectRolePage from './pages/SelectRolePage';
@@ -9,6 +9,7 @@ import ErrorPage from './pages/ErrorPage';
 import AppLayout from './layouts/AppLayout';
 import CoachingPage from './pages/CoachingPage';
 import HistoryPage from './pages/HistoryPage';
+import HistoryDetailPage from './pages/HistoryDetailPage';
 import ReviewPage from './pages/ReviewPage';
 import MyPage from './pages/MyPage';
 
@@ -31,7 +32,16 @@ const router = createBrowserRouter([
           },
           {
             path: 'history',
-            element: <HistoryPage />,
+            children: [
+              {
+                index: true,
+                element: <HistoryPage />,
+              },
+              {
+                path: ':id',
+                element: <HistoryDetailPage />,
+              },
+            ],
           },
           {
             path: 'review',

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -32,11 +32,8 @@ const router = createBrowserRouter([
           },
           {
             path: 'history',
+            element: <HistoryPage />, // 부모로 이동
             children: [
-              {
-                index: true,
-                element: <HistoryPage />,
-              },
               {
                 path: ':id',
                 element: <HistoryDetailPage />,

--- a/src/assets/icons/Right.svg
+++ b/src/assets/icons/Right.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.833008 10.833L5.83301 5.83301L0.833008 0.833008" stroke="#99A1AF" stroke-width="1.66596" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/index.tsx
+++ b/src/assets/index.tsx
@@ -12,6 +12,7 @@ import SecondHomeIcon from '@/assets/icons/HomeIcon2.svg?react';
 import ThirdomeIcon from '@/assets/icons/HomeIcon3.svg?react';
 import ForthHomeIcon from '@/assets/icons/HomeIcon4.svg?react';
 import FeedbackIcon from '@/assets/icons/Feedback.svg?react';
+import RightIcon from '@/assets/icons/Right.svg?react';
 
 export {
   Logo,
@@ -28,4 +29,5 @@ export {
   ThirdomeIcon,
   ForthHomeIcon,
   FeedbackIcon,
+  RightIcon,
 };

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai';
 
 const pageAtom = atom<number>(1);
+const isModalOpenAtom = atom<boolean>(false);
 
-export { pageAtom };
+export { pageAtom, isModalOpenAtom };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -11,7 +11,7 @@ interface ButtonProps {
 
 const Button = ({ children, type, className, disabled = false, onClick }: ButtonProps) => {
   const baseStyle =
-    'px-4 py-3 rounded-lg flex items-center justify-center gap-2 hover:brightness-90 transition-all'; // 버튼 기본 스타일
+    'rounded-lg flex items-center justify-center gap-1 hover:brightness-90 transition-all'; // 버튼 기본 스타일
 
   return (
     <button

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -16,14 +16,14 @@ const Modal = ({ title, content, onConfirm, onCancel }: ModalProps) => {
         <Button
           type='button'
           onClick={onConfirm}
-          className='bg-black text-white text-sm font-semibold mt-1'
+          className='bg-black text-white text-sm font-semibold mt-1 p-2.5'
         >
           삭제
         </Button>
         <Button
           type='button'
           onClick={onCancel}
-          className='bg-white border border-[#DADADA] text-sm font-semibold'
+          className='bg-white border border-[#DADADA] text-sm font-semibold p-2.5'
         >
           취소
         </Button>

--- a/src/components/layouts/MobileFooter.tsx
+++ b/src/components/layouts/MobileFooter.tsx
@@ -1,11 +1,15 @@
+import { pageAtom } from '@/atoms';
 import { menuItems } from '@/data/menuItems';
 import clsx from 'clsx';
+import { useSetAtom } from 'jotai';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const MobileFooter = () => {
   const navigate = useNavigate();
   const location = useLocation();
+
+  const setPage = useSetAtom(pageAtom);
 
   return (
     <nav className='fixed bottom-0 left-0 w-full bg-white border-t border-gray-200 sm:hidden'>
@@ -17,7 +21,12 @@ const MobileFooter = () => {
           return (
             <button
               key={item.id}
-              onClick={() => navigate(item.path)}
+              onClick={() => {
+                if (item.path === '/coaching') {
+                  setPage(1);
+                }
+                navigate(item.path);
+              }}
               className='flex flex-col items-center gap-1 px-3'
             >
               <Icon className={clsx('w-6 h-6', isActive ? 'text-black' : 'text-gray-500')} />

--- a/src/components/layouts/MobileFooter.tsx
+++ b/src/components/layouts/MobileFooter.tsx
@@ -16,7 +16,8 @@ const MobileFooter = () => {
       <div className='flex justify-around py-3'>
         {menuItems.map((item) => {
           const Icon = item.icon;
-          const isActive = location.pathname === item.path;
+          const isActive =
+            item.path === '/' ? location.pathname === '/' : location.pathname.startsWith(item.path);
 
           return (
             <button

--- a/src/components/layouts/MobileHeader.tsx
+++ b/src/components/layouts/MobileHeader.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import HomeHeader from './headers/HomeHeader';
 import CoachingHeader from './headers/CoachingHeader';
+import HistoryHeader from './headers/HistoryHeader';
 
 const MobileHeader = () => {
   const location = useLocation();
@@ -8,6 +9,7 @@ const MobileHeader = () => {
   const renderHeader = () => {
     if (location.pathname === '/') return <HomeHeader />;
     if (location.pathname.startsWith('/coaching')) return <CoachingHeader />;
+    if (location.pathname.startsWith('/history')) return <HistoryHeader />;
   };
 
   return <header className='bg-black sm:hidden'>{renderHeader()}</header>;

--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -61,7 +61,8 @@ const SideBar = () => {
       <nav className='flex-1 p-4'>
         {menuItems.map((item) => {
           const Icon = item.icon;
-          const isActive = location.pathname === item.path;
+          const isActive =
+            item.path === '/' ? location.pathname === '/' : location.pathname.startsWith(item.path);
 
           return (
             <button

--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -1,11 +1,14 @@
+import { pageAtom } from '@/atoms';
 import { menuItems } from '@/data/menuItems';
 import clsx from 'clsx';
+import { useSetAtom } from 'jotai';
 import { Menu, PanelLeft } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const SideBar = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const setPage = useSetAtom(pageAtom);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -63,7 +66,12 @@ const SideBar = () => {
           return (
             <button
               key={item.id}
-              onClick={() => navigate(item.path)}
+              onClick={() => {
+                if (item.path === '/coaching') {
+                  setPage(1);
+                }
+                navigate(item.path);
+              }}
               className={clsx(
                 'w-full flex items-center mb-2 rounded-lg py-3 transition-colors px-3.5 gap-3',
                 isActive ? 'bg-black text-white' : 'hover:bg-gray-200',

--- a/src/components/layouts/headers/CoachingHeader.tsx
+++ b/src/components/layouts/headers/CoachingHeader.tsx
@@ -8,7 +8,7 @@ const CoachingHeader = () => {
 
   return (
     <div className='flex flex-col p-6'>
-      <h3 className='text-white text-lg font-semibold mb-2'>면접 코칭</h3>
+      <h3 className='text-white text-xl font-semibold mb-2'>면접 코칭</h3>
       <div className='flex gap-3'>
         {coachStep.map((step) => (
           <div

--- a/src/components/layouts/headers/HistoryHeader.tsx
+++ b/src/components/layouts/headers/HistoryHeader.tsx
@@ -1,0 +1,23 @@
+import Button from '@/components/common/Button';
+import { FaRegTrashAlt } from 'react-icons/fa';
+
+const HistoryHeader = () => {
+  return (
+    <div className='flex justify-between items-center p-6'>
+      <div className='text-white'>
+        <h3 className='text-xl font-semibold mb-1'>히스토리</h3>
+        <p className='text-lg'>내 답변 기록</p>
+      </div>
+
+      <Button
+        type='button'
+        className='bg-white font-medium text-sm px-2.5 py-2 border border-[#E5E5E5]'
+      >
+        <FaRegTrashAlt size={16} />
+        전체 삭제
+      </Button>
+    </div>
+  );
+};
+
+export default HistoryHeader;

--- a/src/components/layouts/headers/HistoryHeader.tsx
+++ b/src/components/layouts/headers/HistoryHeader.tsx
@@ -1,7 +1,11 @@
+import { isModalOpenAtom } from '@/atoms';
 import Button from '@/components/common/Button';
+import { useSetAtom } from 'jotai';
 import { FaRegTrashAlt } from 'react-icons/fa';
 
 const HistoryHeader = () => {
+  const setIsModalOpen = useSetAtom(isModalOpenAtom);
+
   return (
     <div className='flex justify-between items-center p-6'>
       <div className='text-white'>
@@ -12,6 +16,7 @@ const HistoryHeader = () => {
       <Button
         type='button'
         className='bg-white font-medium text-sm px-2.5 py-2 border border-[#E5E5E5]'
+        onClick={() => setIsModalOpen((prev) => !prev)}
       >
         <FaRegTrashAlt size={16} />
         전체 삭제

--- a/src/index.css
+++ b/src/index.css
@@ -80,3 +80,16 @@ a {
 button {
   cursor: pointer;
 }
+
+/* Hide scrollbar */
+.hide-scrollbar {
+  scrollbar-width: none;
+  /* Firefox */
+  -ms-overflow-style: none;
+  /* IE, Edge */
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+  /* Chrome, Safari, Opera */
+}

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -45,8 +45,8 @@ const AppLayout = () => {
 
       {isModalOpen && (
         <Modal
-          title='해당 히스토리를 삭제하시겠습니까?'
-          content='이 작업은 되돌릴 수 없습니다. 모든 면접 답변 기록이 영구적으로 삭제됩니다.'
+          title='모든 히스토리를 삭제하시겠습니까?'
+          content='이 작업은 되돌릴 수 없습니다.'
           onCancel={() => setIsModalOpen((prev) => !prev)}
           onConfirm={handleDelete}
         />

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -2,8 +2,33 @@ import { Outlet } from 'react-router-dom';
 import SideBar from '@/components/layouts/SideBar';
 import MobileHeader from '@/components/layouts/MobileHeader';
 import MobileFooter from '@/components/layouts/MobileFooter';
+import Modal from '@/components/common/Modal';
+import { useAtom } from 'jotai';
+import { isModalOpenAtom } from '@/atoms';
+import { showToast } from '@/utils/toast';
+import { useEffect } from 'react';
 
 const AppLayout = () => {
+  const [isModalOpen, setIsModalOpen] = useAtom(isModalOpenAtom);
+
+  const handleDelete = () => {
+    setIsModalOpen((prev) => !prev);
+    showToast.success('삭제되었습니다');
+  };
+
+  useEffect(() => {
+    if (!isModalOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsModalOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isModalOpen, setIsModalOpen]);
+
   return (
     <div className='flex h-screen bg-gray-50'>
       <SideBar />
@@ -17,6 +42,15 @@ const AppLayout = () => {
       </main>
 
       <MobileFooter />
+
+      {isModalOpen && (
+        <Modal
+          title='해당 히스토리를 삭제하시겠습니까?'
+          content='이 작업은 되돌릴 수 없습니다. 모든 면접 답변 기록이 영구적으로 삭제됩니다.'
+          onCancel={() => setIsModalOpen((prev) => !prev)}
+          onConfirm={handleDelete}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/CoachingPage.tsx
+++ b/src/pages/CoachingPage.tsx
@@ -118,8 +118,8 @@ const CoachingPage = () => {
       {page === 2 && (
         <>
           <div className='bg-black rounded-xl p-6 flex flex-col gap-4 text-white'>
-            <p className='font-semibold'>질문</p>
-            <p>{selectedQuestion || customQuestion}</p>
+            <p className='font-semibold'>선택된 질문</p>
+            <p>{customQuestion || selectedQuestion}</p>
           </div>
 
           <div className='bg-white rounded-xl px-6 py-4 border border-[#E5E5E5] flex flex-col gap-4'>
@@ -142,7 +142,7 @@ const CoachingPage = () => {
               <FaAngleLeft /> 이전
             </Button>
             <Button
-              type='button'
+              type='submit'
               className='w-full bg-black text-white font-medium px-4 py-3 gap-2'
               onClick={handleNextStep}
             >
@@ -156,8 +156,8 @@ const CoachingPage = () => {
       {page === 3 && (
         <>
           <div className='bg-black rounded-xl p-6 flex flex-col gap-4 text-white'>
-            <p className='font-semibold'>질문</p>
-            <p>{selectedQuestion || customQuestion}</p>
+            <p className='font-semibold'>선택된 질문</p>
+            <p>{customQuestion || selectedQuestion}</p>
           </div>
 
           <div className='bg-white rounded-xl p-6 flex flex-col gap-4 border border-[#E5E5E5]'>
@@ -176,7 +176,7 @@ const CoachingPage = () => {
               className='w-full bg-black text-white px-4 py-3 gap-2'
               onClick={() => setShowExampleAnswer((prev) => !prev)}
             >
-              <LuLightbulb size={18} />{' '}
+              <LuLightbulb size={18} />
               {showExampleAnswer ? '모범 답변 숨기기' : '모범 답변 예시 보기'}
             </Button>
 
@@ -198,11 +198,11 @@ const CoachingPage = () => {
                   className='border border-black/10 text-sm font-medium gap-1.5 p-2 px-3 bg-white'
                   onClick={() => {
                     navigator.clipboard.writeText(feedback);
-                    showToast.success('복사되었습니다');
+                    showToast.success('히스토리에 저장되었습니다');
                   }}
                 >
                   <FiSave size={18} />
-                  복사
+                  저장
                 </Button>
               </div>
               <div className='bg-[#F3F3F5] rounded-lg p-4 text-sm mb-2'>{feedback}</div>

--- a/src/pages/CoachingPage.tsx
+++ b/src/pages/CoachingPage.tsx
@@ -52,10 +52,11 @@ const CoachingPage = () => {
     setSelectedQuestion(null);
     setCustomQuestion('');
     setCustomAnswer('');
+    setShowExampleAnswer(false);
   };
 
   return (
-    <div className='space-y-5 relative'>
+    <div className='space-y-5 relative sm:max-w-200 sm:mx-auto pb-30'>
       <div className='hidden sm:flex flex-col my-10'>
         <h3 className='text-2xl font-semibold mb-2'>면접 코칭</h3>
         <p className='text-[#717182] mb-6'>질문에 답변하고 AI로부터 즉각적인 피드백을 받아보세요</p>
@@ -106,7 +107,7 @@ const CoachingPage = () => {
 
           <Button
             type='button'
-            className='w-full bg-black text-white font-medium'
+            className='w-full bg-black text-white font-medium sm:max-w-[80%] sm:mx-auto mt-10 px-4 py-3 gap-2'
             onClick={handleNextStep}
           >
             다음 <FaAngleRight />
@@ -132,17 +133,17 @@ const CoachingPage = () => {
             />
           </div>
 
-          <div className='flex items-center gap-5'>
+          <div className='flex items-center gap-5 sm:max-w-[80%] sm:mx-auto mt-10'>
             <Button
               type='button'
-              className='w-full ring bg-gray-50 ring-[#DADADA] font-medium'
+              className='w-full ring bg-gray-50 ring-[#DADADA] font-medium px-4 py-3 gap-2'
               onClick={() => setPage((prev) => prev - 1)}
             >
               <FaAngleLeft /> 이전
             </Button>
             <Button
               type='button'
-              className='w-full bg-black text-white font-medium'
+              className='w-full bg-black text-white font-medium px-4 py-3 gap-2'
               onClick={handleNextStep}
             >
               <FeedbackIcon />
@@ -169,28 +170,32 @@ const CoachingPage = () => {
             <div className='bg-[#F3F3F5] rounded-lg p-4 text-sm mb-2'>넌 안돼 망할거라 우우~</div>
           </div>
 
-          <div className='flex max-sm:flex-col items-center gap-5'>
+          <div className='flex max-sm:flex-col items-center gap-5 sm:max-w-[80%] sm:mx-auto mt-10'>
             <Button
               type='button'
-              className='w-full bg-black text-white'
+              className='w-full bg-black text-white px-4 py-3 gap-2'
               onClick={() => setShowExampleAnswer((prev) => !prev)}
             >
               <LuLightbulb size={18} />{' '}
               {showExampleAnswer ? '모범 답변 숨기기' : '모범 답변 예시 보기'}
             </Button>
 
-            <Button type='button' className='w-full bg-black text-white' onClick={newCoaching}>
+            <Button
+              type='button'
+              className='w-full bg-black text-white px-4 py-3 gap-2'
+              onClick={newCoaching}
+            >
               <LuRotateCcw size={18} /> 새로운 질문 연습하기
             </Button>
           </div>
 
           {showExampleAnswer && (
-            <div className='bg-white rounded-xl px-6 py-4  border border-[#E5E5E5] flex flex-col gap-4 mb-30'>
+            <div className='bg-white rounded-xl px-6 py-4  border border-[#E5E5E5] flex flex-col gap-4'>
               <div className='flex items-center justify-between'>
                 <p className='font-semibold'>📝 모범 답변 예시</p>
-                <button
+                <Button
                   type='button'
-                  className='border border-black/10 rounded-lg text-sm font-medium flex items-center justify-center gap-1.5 p-2 px-3 bg-white hover:brightness-90 transition'
+                  className='border border-black/10 text-sm font-medium gap-1.5 p-2 px-3 bg-white'
                   onClick={() => {
                     navigator.clipboard.writeText(feedback);
                     showToast.success('복사되었습니다');
@@ -198,7 +203,7 @@ const CoachingPage = () => {
                 >
                   <FiSave size={18} />
                   복사
-                </button>
+                </Button>
               </div>
               <div className='bg-[#F3F3F5] rounded-lg p-4 text-sm mb-2'>{feedback}</div>
             </div>

--- a/src/pages/HistoryDetailPage.tsx
+++ b/src/pages/HistoryDetailPage.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { FaRegTrashAlt } from 'react-icons/fa';
 import { FiCalendar } from 'react-icons/fi';
 import { IoIosClose } from 'react-icons/io';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -42,9 +43,23 @@ const HistoryDetailPage = () => {
     setTimeout(() => setOpen(true), 10); // mount 후 transition 트리거
   }, []);
 
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
   const handleClose = () => {
     setOpen(false);
-    setTimeout(() => navigate(-1), 200); // 애니메이션 끝난 뒤 닫기
+    setTimeout(() => navigate('/history'), 200); // 애니메이션 끝난 뒤 닫기
   };
 
   if (!item) return null;
@@ -52,18 +67,19 @@ const HistoryDetailPage = () => {
   return (
     <div
       className={clsx(
-        'fixed inset-0 bg-black/40 transition-opacity duration-200 ',
+        'fixed inset-0 bg-black/40 transition-opacity duration-300 ',
         open ? 'opacity-100' : 'opacity-0',
       )}
       onClick={handleClose}
     >
-      <div
+      <main
+        onClick={(e) => e.stopPropagation()}
         className={clsx(
-          'fixed bottom-0 left-0 right-0 h-[80vh] bg-white rounded-t-2xl shadow-xl p-8 transition-transform duration-300',
+          'fixed bottom-0 left-0 right-0 h-[80vh] bg-white rounded-t-2xl shadow-xl p-8 transition-transform duration-300 overflow-y-auto hide-scrollbar',
           open ? 'translate-y-0' : 'translate-y-full',
         )}
       >
-        <div className='flex items-center justify-between px-2 mb-10'>
+        <section className='flex items-center justify-between px-2 mb-10'>
           <div className='flex flex-row items-center justify-center gap-5'>
             <div className='bg-black text-white text-xs font-medium p-1 px-4 border border-[#E5E5E5] rounded-lg'>
               {item.category}
@@ -73,19 +89,49 @@ const HistoryDetailPage = () => {
               {item.date}
             </p>
           </div>
-          <button
-            onClick={handleClose}
-            className='text-[#0A0A0A] bg-white rounded-full hover:brightness-90 transition'
-          >
-            <IoIosClose size={30} />
-          </button>
-        </div>
+          <div className='flex items-center gap-2'>
+            <button
+              type='button'
+              className='bg-white rounded-full p-2 hover:brightness-90 transition'
+            >
+              <FaRegTrashAlt size={16} className='text-[#FB2C36]' />
+            </button>
+            <button
+              onClick={handleClose}
+              className='text-[#0A0A0A] bg-white rounded-full hover:brightness-90 transition'
+            >
+              <IoIosClose size={30} />
+            </button>
+          </div>
+        </section>
 
-        <div className='mt-4 p-4 bg-white rounded-xl border border-gray-200'>
-          <p className='font-medium text-lg mb-2'>{item.question}</p>
-          <p className='text-gray-700'>{item.answer}</p>
-        </div>
-      </div>
+        <section className='space-y-5 mb-20'>
+          <div className='bg-black rounded-xl p-6 flex flex-col gap-4 text-white'>
+            <p className='font-semibold'>질문</p>
+            <p>{item.question}</p>
+          </div>
+
+          <div className='bg-white rounded-xl p-6 flex flex-col gap-4 border border-[#E5E5E5]'>
+            <p className='font-semibold'>내 답변</p>
+            <p>{item.answer}</p>
+          </div>
+
+          <div className='bg-white rounded-xl p-6  border border-[#E5E5E5] flex flex-col gap-4'>
+            <p className='font-semibold'>AI 피드백</p>
+            <div className='bg-[#F3F3F5] rounded-lg p-4 text-sm mb-2'>
+              넌 안돼 망할거라 우우~ 넌 안돼 망할거라 우우~ 넌 안돼 망할거라 우우~ 넌 안돼 망할거라
+              우우~
+            </div>
+          </div>
+
+          <div className='bg-white rounded-xl px-6 py-4  border border-[#E5E5E5] flex flex-col gap-4'>
+            <p className='font-semibold'>📝 모범 답변 예시</p>
+            <div className='bg-[#F3F3F5] rounded-lg p-4 text-sm mb-2'>
+              피드백피드백피드백피드백피드백 피드백 피드백 피드백 피드백 피드백 피드백 피드백
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
   );
 };

--- a/src/pages/HistoryDetailPage.tsx
+++ b/src/pages/HistoryDetailPage.tsx
@@ -1,4 +1,8 @@
-import { useParams } from 'react-router-dom';
+import clsx from 'clsx';
+import { useEffect, useState } from 'react';
+import { FiCalendar } from 'react-icons/fi';
+import { IoIosClose } from 'react-icons/io';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const mockHistoryItems = [
   {
@@ -28,18 +32,59 @@ const mockHistoryItems = [
 
 const HistoryDetailPage = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
+
   const item = mockHistoryItems.find((h) => h.id === Number(id));
 
-  if (!item) return <p>존재하지 않는 히스토리입니다.</p>;
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => setOpen(true), 10); // mount 후 transition 트리거
+  }, []);
+
+  const handleClose = () => {
+    setOpen(false);
+    setTimeout(() => navigate(-1), 200); // 애니메이션 끝난 뒤 닫기
+  };
+
+  if (!item) return null;
 
   return (
-    <div className='p-6 space-y-4'>
-      <h2 className='text-2xl font-semibold'>{item.category}</h2>
-      <p className='text-gray-500'>{item.date}</p>
+    <div
+      className={clsx(
+        'fixed inset-0 bg-black/40 transition-opacity duration-200 ',
+        open ? 'opacity-100' : 'opacity-0',
+      )}
+      onClick={handleClose}
+    >
+      <div
+        className={clsx(
+          'fixed bottom-0 left-0 right-0 h-[80vh] bg-white rounded-t-2xl shadow-xl p-8 transition-transform duration-300',
+          open ? 'translate-y-0' : 'translate-y-full',
+        )}
+      >
+        <div className='flex items-center justify-between px-2 mb-10'>
+          <div className='flex flex-row items-center justify-center gap-5'>
+            <div className='bg-black text-white text-xs font-medium p-1 px-4 border border-[#E5E5E5] rounded-lg'>
+              {item.category}
+            </div>
+            <p className='text-[#6A7282] flex items-center gap-1'>
+              <FiCalendar size={18} />
+              {item.date}
+            </p>
+          </div>
+          <button
+            onClick={handleClose}
+            className='text-[#0A0A0A] bg-white rounded-full hover:brightness-90 transition'
+          >
+            <IoIosClose size={30} />
+          </button>
+        </div>
 
-      <div className='mt-4 p-4 bg-white rounded-xl border border-gray-200'>
-        <p className='font-medium text-lg mb-2'>{item.question}</p>
-        <p className='text-gray-700'>{item.answer}</p>
+        <div className='mt-4 p-4 bg-white rounded-xl border border-gray-200'>
+          <p className='font-medium text-lg mb-2'>{item.question}</p>
+          <p className='text-gray-700'>{item.answer}</p>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/HistoryDetailPage.tsx
+++ b/src/pages/HistoryDetailPage.tsx
@@ -1,0 +1,48 @@
+import { useParams } from 'react-router-dom';
+
+const mockHistoryItems = [
+  {
+    id: 1,
+    category: '경험',
+    date: '오늘',
+    question: '코드 리뷰에서 가장 중요하게 생각하는 것은?',
+    answer:
+      '코드 컨벤션을 지켰는지 확인하면서 리뷰를 하는 것이 가장 중요하다고 생각합니다. 왜냐하면 중요하다고 생각하기 때문입니다.',
+  },
+  {
+    id: 2,
+    category: '인성',
+    date: '25.10.27',
+    question: '인성 문제있어요?',
+    answer: '없는데요? 왜 물어보세요 그런거',
+  },
+  {
+    id: 3,
+    category: '개발',
+    date: '24.9.10',
+    question: '개발이 좋으세요? 아니면 고양이발이 좋으세요?',
+    answer:
+      '저는 개인적으로 고양이 발이 더 좋습니다. 고양이 발바닥을 보시면 핑크색 젤리가 있는데 그게 참 야무지거든요.',
+  },
+];
+
+const HistoryDetailPage = () => {
+  const { id } = useParams();
+  const item = mockHistoryItems.find((h) => h.id === Number(id));
+
+  if (!item) return <p>존재하지 않는 히스토리입니다.</p>;
+
+  return (
+    <div className='p-6 space-y-4'>
+      <h2 className='text-2xl font-semibold'>{item.category}</h2>
+      <p className='text-gray-500'>{item.date}</p>
+
+      <div className='mt-4 p-4 bg-white rounded-xl border border-gray-200'>
+        <p className='font-medium text-lg mb-2'>{item.question}</p>
+        <p className='text-gray-700'>{item.answer}</p>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryDetailPage;

--- a/src/pages/HistoryDetailPage.tsx
+++ b/src/pages/HistoryDetailPage.tsx
@@ -91,7 +91,8 @@ const HistoryDetailPage = () => {
       <main
         onClick={(e) => e.stopPropagation()}
         className={clsx(
-          'fixed bottom-0 left-0 right-0 h-[80vh] bg-white rounded-t-2xl shadow-xl p-8 transition-transform duration-300 overflow-y-auto hide-scrollbar',
+          'fixed bottom-0 left-1/2 transform -translate-x-1/2 h-[80vh] bg-white rounded-t-2xl shadow-xl transition-transform duration-300 overflow-y-auto hide-scrollbar',
+          'w-full max-w-4xl p-8',
           isOpen ? 'translate-y-0' : 'translate-y-full',
         )}
       >

--- a/src/pages/HistoryDetailPage.tsx
+++ b/src/pages/HistoryDetailPage.tsx
@@ -1,3 +1,5 @@
+import Modal from '@/components/common/Modal';
+import { showToast } from '@/utils/toast';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import { FaRegTrashAlt } from 'react-icons/fa';
@@ -37,17 +39,23 @@ const HistoryDetailPage = () => {
 
   const item = mockHistoryItems.find((h) => h.id === Number(id));
 
-  const [open, setOpen] = useState(false);
+  const [isOpen, setISOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    setTimeout(() => setOpen(true), 10); // mount 후 transition 트리거
+    setTimeout(() => setISOpen(true), 10); // mount 후 transition 트리거
   }, []);
 
   useEffect(() => {
-    if (!open) return;
-
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key !== 'Escape') return;
+
+      if (isModalOpen) {
+        setIsModalOpen(false);
+        return;
+      }
+
+      if (isOpen) {
         handleClose();
       }
     };
@@ -55,11 +63,17 @@ const HistoryDetailPage = () => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [isModalOpen, isOpen]);
 
   const handleClose = () => {
-    setOpen(false);
+    setISOpen(false);
     setTimeout(() => navigate('/history'), 200); // 애니메이션 끝난 뒤 닫기
+  };
+
+  const handleDelete = () => {
+    setIsModalOpen((prev) => !prev);
+    showToast.success('삭제되었습니다');
+    navigate('/history');
   };
 
   if (!item) return null;
@@ -68,15 +82,17 @@ const HistoryDetailPage = () => {
     <div
       className={clsx(
         'fixed inset-0 bg-black/40 transition-opacity duration-300 ',
-        open ? 'opacity-100' : 'opacity-0',
+        isOpen ? 'opacity-100' : 'opacity-0',
       )}
-      onClick={handleClose}
+      onClick={() => {
+        if (!isModalOpen) handleClose();
+      }}
     >
       <main
         onClick={(e) => e.stopPropagation()}
         className={clsx(
           'fixed bottom-0 left-0 right-0 h-[80vh] bg-white rounded-t-2xl shadow-xl p-8 transition-transform duration-300 overflow-y-auto hide-scrollbar',
-          open ? 'translate-y-0' : 'translate-y-full',
+          isOpen ? 'translate-y-0' : 'translate-y-full',
         )}
       >
         <section className='flex items-center justify-between px-2 mb-10'>
@@ -92,7 +108,8 @@ const HistoryDetailPage = () => {
           <div className='flex items-center gap-2'>
             <button
               type='button'
-              className='bg-white rounded-full p-2 hover:brightness-90 transition'
+              onClick={() => setIsModalOpen((prev) => !prev)}
+              className='bg-white rounded-full p-2 hover:brightness-90 transition outline-none'
             >
               <FaRegTrashAlt size={16} className='text-[#FB2C36]' />
             </button>
@@ -132,6 +149,15 @@ const HistoryDetailPage = () => {
           </div>
         </section>
       </main>
+
+      {isModalOpen && (
+        <Modal
+          title='해당 히스토리를 삭제하시겠습니까?'
+          content='이 작업은 되돌릴 수 없습니다. 모든 면접 답변 기록이 영구적으로 삭제됩니다.'
+          onCancel={() => setIsModalOpen((prev) => !prev)}
+          onConfirm={handleDelete}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,5 +1,27 @@
+import { FiCalendar } from 'react-icons/fi';
+
 const HistoryPage = () => {
-  return <div></div>;
+  return (
+    <div className='space-y-5 relative pb-30'>
+      <div className='hidden sm:flex flex-col my-10'>
+        <h3 className='text-2xl font-semibold mb-2'>히스토리</h3>
+        <p className='text-[#717182] mb-6'>과거 연습 기록을 확인하고 발전 과정을 추적하세요</p>
+      </div>
+
+      <div className='bg-white rounded-xl px-6 py-5 border border-[#E5E5E5] flex flex-col gap-4'>
+        <div className='flex items-center justify-between'>
+          <div className='bg-black text-white text-xs font-medium p-1 px-4 border border-[#E5E5E5] rounded-lg'>
+            협업
+          </div>
+          <p className='text-[#6A7282] font-medium flex items-center gap-1'>
+            <FiCalendar size={18} />
+            오늘
+          </p>
+        </div>
+        <p>코드 리뷰에서 가장 중요하게 생각하는 것은?</p>
+      </div>
+    </div>
+  );
 };
 
 export default HistoryPage;

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,6 +1,36 @@
+import { RightIcon } from '@/assets';
 import { FiCalendar } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
+
+const historyItems = [
+  {
+    id: 1,
+    category: '경험',
+    date: '오늘',
+    question: '코드 리뷰에서 가장 중요하게 생각하는 것은?',
+    answer:
+      '코드 컨벤션을 지켰는지 확인하면서 리뷰를 하는 것이 가장 중요하다고 생각합니다. 왜냐하면 중요하다고 생각하기 때문입니다. 코드 컨벤션을 지켰는지 확인하면서 리뷰를 하는 것이 가장 중요하다고 생각합니다. 왜냐하면 중요하다고 생각하기 때문입니다.',
+  },
+  {
+    id: 2,
+    category: '인성',
+    date: '25.10.27',
+    question: '인성 문제있어요?',
+    answer: '없는데요? 왜 물어보세요 그런거',
+  },
+  {
+    id: 3,
+    category: '개발',
+    date: '24.9.10',
+    question: '개발이 좋으세요? 아니면 고양이발이 좋으세요?',
+    answer:
+      '저는 개인적으로 고양이 발이 더 좋습니다. 고양이 발바닥을 보시면 핑크색 젤리가 있는데 그게 참 야무지거든요.',
+  },
+];
 
 const HistoryPage = () => {
+  const navigate = useNavigate();
+
   return (
     <div className='space-y-5 relative pb-30'>
       <div className='hidden sm:flex flex-col my-10'>
@@ -8,18 +38,33 @@ const HistoryPage = () => {
         <p className='text-[#717182] mb-6'>과거 연습 기록을 확인하고 발전 과정을 추적하세요</p>
       </div>
 
-      <div className='bg-white rounded-xl px-6 py-5 border border-[#E5E5E5] flex flex-col gap-4'>
-        <div className='flex items-center justify-between'>
-          <div className='bg-black text-white text-xs font-medium p-1 px-4 border border-[#E5E5E5] rounded-lg'>
-            협업
+      {historyItems.map((item) => (
+        <div
+          key={item.id}
+          className='bg-white rounded-xl px-6 py-5 border border-[#E5E5E5] flex flex-col gap-4'
+        >
+          <div className='flex items-center justify-between mb-2'>
+            <div className='bg-black text-white text-xs font-medium p-1 px-4 border border-[#E5E5E5] rounded-lg'>
+              {item.category}
+            </div>
+            <p className='text-[#6A7282] flex items-center gap-1'>
+              <FiCalendar size={18} />
+              {item.date}
+            </p>
           </div>
-          <p className='text-[#6A7282] font-medium flex items-center gap-1'>
-            <FiCalendar size={18} />
-            오늘
-          </p>
+
+          <p>{item.question}</p>
+
+          <button
+            type='button'
+            onClick={() => navigate(`/history/${item.id}`)}
+            className='flex flex-row items-center gap-1 mt-1 cursor-pointer justify-between'
+          >
+            <p className='line-clamp-1 text-[#99A1AF]'>{item.answer}</p>
+            <RightIcon className='h-4 w-4' />
+          </button>
         </div>
-        <p>코드 리뷰에서 가장 중요하게 생각하는 것은?</p>
-      </div>
+      ))}
     </div>
   );
 };

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,4 +1,8 @@
 import { RightIcon } from '@/assets';
+import { isModalOpenAtom } from '@/atoms';
+import Button from '@/components/common/Button';
+import { useSetAtom } from 'jotai';
+import { FaRegTrashAlt } from 'react-icons/fa';
 import { FiCalendar } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
@@ -29,13 +33,24 @@ const historyItems = [
 ];
 
 const HistoryPage = () => {
+  const setIsModalOpen = useSetAtom(isModalOpenAtom);
   const navigate = useNavigate();
 
   return (
     <div className='space-y-5 relative pb-30'>
-      <div className='hidden sm:flex flex-col my-10'>
-        <h3 className='text-2xl font-semibold mb-2'>히스토리</h3>
-        <p className='text-[#717182] mb-6'>과거 연습 기록을 확인하고 발전 과정을 추적하세요</p>
+      <div className='flex items-center justify-between'>
+        <div className='hidden sm:flex flex-col mt-10'>
+          <h3 className='text-2xl font-semibold mb-2'>히스토리</h3>
+          <p className='text-[#717182] mb-6'>과거 연습 기록을 확인하고 발전 과정을 추적하세요</p>
+        </div>
+        <Button
+          type='button'
+          className='bg-white font-medium text-sm px-2.5 py-2 border border-[#E5E5E5]'
+          onClick={() => setIsModalOpen((prev) => !prev)}
+        >
+          <FaRegTrashAlt size={16} />
+          전체 삭제
+        </Button>
       </div>
 
       {historyItems.map((item) => (

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/common/Button';
 import { useSetAtom } from 'jotai';
 import { FaRegTrashAlt } from 'react-icons/fa';
 import { FiCalendar } from 'react-icons/fi';
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 const historyItems = [
   {
@@ -37,9 +37,9 @@ const HistoryPage = () => {
   const navigate = useNavigate();
 
   return (
-    <div className='space-y-5 relative pb-30'>
-      <div className='flex items-center justify-between'>
-        <div className='hidden sm:flex flex-col mt-10'>
+    <div className='space-y-5 relative pb-30 '>
+      <div className='hidden sm:flex items-center justify-between'>
+        <div className='flex flex-col mt-10'>
           <h3 className='text-2xl font-semibold mb-2'>히스토리</h3>
           <p className='text-[#717182] mb-6'>과거 연습 기록을 확인하고 발전 과정을 추적하세요</p>
         </div>
@@ -80,6 +80,8 @@ const HistoryPage = () => {
           </button>
         </div>
       ))}
+
+      <Outlet />
     </div>
   );
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -26,7 +26,7 @@ const LoginPage = () => {
         <div className='flex items-center gap-5 mx-5'>
           <Button
             type='submit'
-            className='w-full bg-[#FEE500] font-medium'
+            className='w-full bg-[#FEE500] font-medium px-4 py-3 gap-2'
             onClick={() => {
               navigate('/role');
               showToast.success('카카오 로그인 성공!');

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -78,21 +78,25 @@ const OnboardingPage = () => {
           <footer className='flex items-center gap-5'>
             <Button
               type='button'
-              className='w-full ring bg-gray-50 ring-[#DADADA] font-medium'
+              className='w-full ring bg-gray-50 ring-[#DADADA] font-medium px-4 py-3 gap-2'
               onClick={goPrev}
             >
               <FaAngleLeft /> 이전
             </Button>
             <Button
               type='button'
-              className='w-full bg-black text-white font-medium'
+              className='w-full bg-black text-white font-medium px-4 py-3 gap-2'
               onClick={goNext}
             >
               다음 <FaAngleRight />
             </Button>
           </footer>
         ) : (
-          <Button type='button' className='w-full bg-black text-white font-medium' onClick={goNext}>
+          <Button
+            type='button'
+            className='w-full bg-black text-white font-medium px-4 py-3 gap-2'
+            onClick={goNext}
+          >
             다음 <FaAngleRight />
           </Button>
         )}

--- a/src/pages/SelectRolePage.tsx
+++ b/src/pages/SelectRolePage.tsx
@@ -66,7 +66,7 @@ const SelectRolePage = () => {
         <footer className='flex items-center gap-5'>
           <Button
             type='submit'
-            className='w-full bg-black text-white font-medium'
+            className='w-full bg-black text-white font-medium px-4 py-3'
             onClick={() => {
               navigate('/');
               showToast.success('환영합니다!');


### PR DESCRIPTION
## 📂 관련 이슈

- closes #9 

---

## 🛠️ 작업 사항

- [x] 히스토리 페이지 UI 구현
  - 일단 mock데이터 추가해서 활용 
- [x] 히스토리 상세 페이지 UI 구현
- [x] 전체/해당 히스토리 삭제 모달 추가

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

### PC
<img width="1912" height="917" alt="image" src="https://github.com/user-attachments/assets/fc6d4dbb-44d1-4ae4-86e6-103459611081" />
<img width="1910" height="915" alt="image" src="https://github.com/user-attachments/assets/8aa20f34-bee3-4c24-a8be-84f51f9a4b3c" />

### 모바일

https://github.com/user-attachments/assets/c1d54ebf-3259-4c4e-b9f0-2c278c38a071


---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.
