### PR TITLE
[Feat] # 히스토리 저장 API 구현

### DIFF
--- a/src/api/history.ts
+++ b/src/api/history.ts
@@ -1,3 +1,4 @@
+import type { SaveHistoryResponse } from '@/types/history';
 import { axiosInstance } from './api';
 
 export interface HistoryItem {
@@ -22,6 +23,13 @@ export interface HistoryListResponse {
     data: HistoryItem[];
   } | null;
 }
+
+export const postHistory = async (coaching_id: number): Promise<SaveHistoryResponse> => {
+  const response = await axiosInstance.post('/history', {
+    coachingId: coaching_id,
+  });
+  return response.data;
+};
 
 export const fetchHistoryList = async (): Promise<HistoryListResponse> => {
   const response = await axiosInstance.get('/history');

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -21,6 +21,7 @@ const aiFeedbackAtom = atom({
   improvementPoints: [] as string[],
   exampleAnswer: '',
 });
+const coachingIdAtom = atom<number | null>(null);
 
 export {
   pageAtom,
@@ -36,4 +37,5 @@ export {
   feedbackLoadingAtom,
   aiFeedbackAtom,
   reviewRefreshAtom,
+  coachingIdAtom,
 };

--- a/src/components/coaching/Step2Answer.tsx
+++ b/src/components/coaching/Step2Answer.tsx
@@ -6,6 +6,7 @@ import type React from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   aiFeedbackAtom,
+  coachingIdAtom,
   companyIdAtom,
   feedbackLoadingAtom,
   jobCategoryIdAtom,
@@ -40,6 +41,7 @@ const Step2Answer = ({
   const questionId = useAtomValue(questionIdAtom);
   const setFeedbackLoading = useSetAtom(feedbackLoadingAtom);
   const setAiFeedback = useSetAtom(aiFeedbackAtom);
+  const setCoachingId = useSetAtom(coachingIdAtom);
 
   const tempFeedbackMutation = useMutation({
     mutationFn: () =>
@@ -63,6 +65,7 @@ const Step2Answer = ({
         exampleAnswer: ai['모범_답변_예시'],
       });
 
+      setCoachingId(res.success.session_id);
       setFeedbackLoading(false);
       showToast.success('피드백이 생성되었습니다.');
     },
@@ -94,6 +97,7 @@ const Step2Answer = ({
         exampleAnswer: ai['모범_답변_예시'] ?? '',
       });
 
+      setCoachingId(res?.success?.session_id);
       setFeedbackLoading(false);
       showToast.success('피드백이 생성되었습니다.');
     },

--- a/src/components/coaching/Step3Feedback.tsx
+++ b/src/components/coaching/Step3Feedback.tsx
@@ -4,13 +4,16 @@ import { FiSave } from 'react-icons/fi';
 import { showToast } from '@/utils/toast';
 import type React from 'react';
 import { useAtomValue } from 'jotai';
-import { aiFeedbackAtom, feedbackLoadingAtom } from '@/atoms';
+import { aiFeedbackAtom, coachingIdAtom, feedbackLoadingAtom } from '@/atoms';
+import { postHistory } from '@/api/history';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import clsx from 'clsx';
 
 interface Props {
   customQuestion: string;
   selectedQuestion: string | null;
   customAnswer: string;
-  feedback: string;
   showExampleAnswer: boolean;
   setShowExampleAnswer: React.Dispatch<React.SetStateAction<boolean>>;
   resetCoaching: () => void;
@@ -20,7 +23,6 @@ const Step3Feedback = ({
   customQuestion,
   selectedQuestion,
   customAnswer,
-  feedback,
   showExampleAnswer,
   setShowExampleAnswer,
   resetCoaching,
@@ -28,6 +30,33 @@ const Step3Feedback = ({
   const isLoading = useAtomValue(feedbackLoadingAtom);
   const { summarizedTalent, companyAdvice, totalReview, improvementPoints, exampleAnswer } =
     useAtomValue(aiFeedbackAtom);
+  const coachingId = useAtomValue(coachingIdAtom);
+  const [isSaved, setIsSaved] = useState(false);
+
+  const saveHistoryMutation = useMutation({
+    mutationFn: () => {
+      if (coachingId === null) {
+        throw new Error('coachingId가 없습니다');
+      }
+      return postHistory(coachingId);
+    },
+    onSuccess: () => {
+      showToast.success('히스토리 저장에 성공했습니다');
+      setIsSaved(true);
+    },
+    onError: () => {
+      showToast.error('히스토리 저장에 실패했습니다');
+    },
+  });
+
+  const handleSaveClick = () => {
+    if (isSaved) {
+      showToast.error('이미 히스토리가 저장되었습니다');
+      return;
+    }
+
+    saveHistoryMutation.mutate();
+  };
 
   return (
     <>
@@ -112,11 +141,12 @@ const Step3Feedback = ({
             <p className='font-semibold'>📝 모범 답변 예시</p>
             <Button
               type='button'
-              className='border border-black/10 text-sm font-medium gap-1.5 p-2 px-3 bg-white'
-              onClick={() => {
-                navigator.clipboard.writeText(feedback);
-                showToast.success('히스토리에 저장되었습니다');
-              }}
+              className={clsx(
+                'border border-black/10 text-sm font-medium gap-1.5 p-2 px-3 bg-white',
+                isSaved && 'opacity-50 hover:brightness-100 pointer-events-none',
+              )}
+              disabled={coachingId === null}
+              onClick={handleSaveClick}
             >
               <FiSave size={18} />
               저장

--- a/src/pages/CoachingPage.tsx
+++ b/src/pages/CoachingPage.tsx
@@ -14,7 +14,6 @@ const CoachingPage = () => {
   const [selectedQuestion, setSelectedQuestion] = useState<string | null>(null);
   const [customQuestion, setCustomQuestion] = useState<string>('');
   const [customAnswer, setCustomAnswer] = useState<string>('');
-  const [feedback, setFeedback] = useState<string>('');
   const [showExampleAnswer, setShowExampleAnswer] = useState<boolean>(false);
 
   const handleNextStep = () => {
@@ -35,8 +34,6 @@ const CoachingPage = () => {
         showToast.error('답변을 작성해주세요');
         return;
       }
-
-      setFeedback('모범 답변 예시입니당');
       setPage((prev) => prev + 1);
     }
   };
@@ -86,7 +83,6 @@ const CoachingPage = () => {
           customQuestion={customQuestion}
           selectedQuestion={selectedQuestion}
           customAnswer={customAnswer}
-          feedback={feedback}
           showExampleAnswer={showExampleAnswer}
           setShowExampleAnswer={setShowExampleAnswer}
           resetCoaching={resetCoaching}

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,12 @@
+import type { CommonResponse } from './common';
+
+export type SaveHistoryItem = {
+  user_id: number;
+  coaching_id: number;
+  history_id: number;
+};
+
+export type SaveHistoryResponse = CommonResponse<{
+  message: string;
+  data: SaveHistoryItem;
+}>;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #49 

---

## 🛠️ 작업 사항

- [ ] 히스토리 저장 API 구현
  - 최초 저장 후에 버튼 비활성화

---

## 📸 관련 이미지 (스크린샷 또는 동영상)


https://github.com/user-attachments/assets/0f507803-ae8a-42b5-92a8-d3e397a69d4a



---

## 💬 기타 설명

> 💡 추가적으로 공유할 내용이나 리뷰어에게 전달할 사항이 있다면 작성해 주세요.
